### PR TITLE
fix(cli): allow worker configuration sync

### DIFF
--- a/packages/cli/src/sync/ignore-patterns.test.ts
+++ b/packages/cli/src/sync/ignore-patterns.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+import { DEFAULT_IGNORE_PATTERNS, shouldIgnorePath } from "./ignore-patterns.js"
+
+describe("sync ignore patterns", () => {
+	it("does not ignore worker-configuration.d.ts during sync", () => {
+		expect(DEFAULT_IGNORE_PATTERNS).not.toContain("worker-configuration.d.ts")
+		expect(shouldIgnorePath("/worker-configuration.d.ts")).toBe(false)
+	})
+
+	it("still ignores generated cloudflare directories", () => {
+		expect(shouldIgnorePath("/.cloudflare/cache/state.json")).toBe(true)
+	})
+})

--- a/packages/cli/src/sync/ignore-patterns.ts
+++ b/packages/cli/src/sync/ignore-patterns.ts
@@ -100,7 +100,6 @@ export const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
   "*.wasm",
 
   // ── Cloudflare / Worker generated files ───────────────────────────────────
-  "worker-configuration.d.ts",
   ".cloudflare",
 
   // ── CLI-injected context (never upload back to remote) ────────────────────


### PR DESCRIPTION
## Summary
- stop ignoring `worker-configuration.d.ts` so Worker configuration types can be synced into jam sessions
- keep `.cloudflare` artifacts excluded from sync
- add a focused test covering both behaviors

## Test plan
- [x] `pnpm run test src/sync/ignore-patterns.test.ts` in `packages/cli`
- [x] repository pre-push build checks passed during `git push`
