### PR TITLE
feat(cli): store Nullshot auth per API URL

### DIFF
--- a/packages/cli/src/auth/auth-manager.test.ts
+++ b/packages/cli/src/auth/auth-manager.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  AuthManager,
+  DEFAULT_API_URL,
+  normalizeApiUrl,
+  type AuthCredentials,
+} from "./auth-manager.js";
+
+function sampleCreds(overrides: Partial<AuthCredentials> = {}): AuthCredentials {
+  return {
+    sessionToken: "tok",
+    userId: "u1",
+    userName: "User",
+    email: "a@b.com",
+    expiresAt: Date.now() + 86400_000,
+    baseUrl: DEFAULT_API_URL,
+    ...overrides,
+  };
+}
+
+describe("normalizeApiUrl", () => {
+  it("strips trailing slashes and matches DEFAULT", () => {
+    expect(normalizeApiUrl("https://nullshot.ai/")).toBe(DEFAULT_API_URL);
+    expect(normalizeApiUrl("https://nullshot.ai")).toBe(DEFAULT_API_URL);
+  });
+
+  it("preserves non-default hosts", () => {
+    expect(normalizeApiUrl("http://127.0.0.1:3000")).toBe("http://127.0.0.1:3000");
+  });
+});
+
+describe("AuthManager", () => {
+  let authFile: string;
+
+  beforeEach(() => {
+    authFile = path.join(os.tmpdir(), `nullshot-auth-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+    process.env.NULLSHOT_AUTH_FILE = authFile;
+  });
+
+  afterEach(() => {
+    delete process.env.NULLSHOT_AUTH_FILE;
+    try {
+      fs.unlinkSync(authFile);
+    } catch {
+      // ignore
+    }
+  });
+
+  it("migrates legacy v1 file to per-URL access", () => {
+    const legacy = {
+      sessionToken: "legacy",
+      userId: "u",
+      userName: null,
+      email: null,
+      expiresAt: Date.now() + 86400_000,
+      baseUrl: "https://test.example/",
+    };
+    fs.mkdirSync(path.dirname(authFile), { recursive: true });
+    fs.writeFileSync(authFile, JSON.stringify(legacy), "utf-8");
+
+    const key = normalizeApiUrl("https://test.example");
+    const creds = AuthManager.getCredentials(key);
+    expect(creds?.sessionToken).toBe("legacy");
+    expect(creds?.baseUrl).toBe(key);
+
+    AuthManager.saveCredentials(sampleCreds({ baseUrl: DEFAULT_API_URL, sessionToken: "prod" }));
+    expect(AuthManager.getAllCredentials()).toHaveLength(2);
+  });
+
+  it("keeps two environments separate", () => {
+    AuthManager.saveCredentials(sampleCreds({ baseUrl: DEFAULT_API_URL, sessionToken: "a" }));
+    AuthManager.saveCredentials(
+      sampleCreds({ baseUrl: "http://localhost:3000", sessionToken: "b", userId: "u2" }),
+    );
+
+    expect(AuthManager.getCredentials(DEFAULT_API_URL)?.sessionToken).toBe("a");
+    expect(AuthManager.getCredentials("http://localhost:3000")?.sessionToken).toBe("b");
+  });
+
+  it("dedupes keys that differ only by trailing slash", () => {
+    AuthManager.saveCredentials(sampleCreds({ baseUrl: "https://foo.dev/", sessionToken: "one" }));
+    AuthManager.saveCredentials(sampleCreds({ baseUrl: "https://foo.dev", sessionToken: "two" }));
+
+    expect(AuthManager.getAllCredentials()).toHaveLength(1);
+    expect(AuthManager.getCredentials("https://foo.dev")?.sessionToken).toBe("two");
+  });
+
+  it("drops only expired entries for one URL", () => {
+    AuthManager.saveCredentials(sampleCreds({ baseUrl: DEFAULT_API_URL, sessionToken: "ok" }));
+    AuthManager.saveCredentials(
+      sampleCreds({
+        baseUrl: "http://old.local",
+        sessionToken: "bad",
+        expiresAt: Date.now() - 1000,
+      }),
+    );
+
+    expect(AuthManager.getCredentials("http://old.local")).toBeNull();
+    expect(AuthManager.getCredentials(DEFAULT_API_URL)?.sessionToken).toBe("ok");
+  });
+
+  it("clearCredentials removes entire file when clearing all", () => {
+    AuthManager.saveCredentials(sampleCreds());
+    AuthManager.clearCredentials();
+    expect(fs.existsSync(authFile)).toBe(false);
+  });
+
+  it("clearCredentials(apiUrl) removes one environment only", () => {
+    AuthManager.saveCredentials(sampleCreds({ baseUrl: DEFAULT_API_URL }));
+    AuthManager.saveCredentials(sampleCreds({ baseUrl: "http://x.local", userId: "x" }));
+
+    AuthManager.clearCredentials("http://x.local");
+    expect(AuthManager.getCredentials("http://x.local")).toBeNull();
+    expect(AuthManager.getCredentials(DEFAULT_API_URL)).not.toBeNull();
+  });
+
+  it("clearCredentials for missing URL does not wipe other logins", () => {
+    AuthManager.saveCredentials(sampleCreds());
+    AuthManager.clearCredentials("http://missing.local");
+    expect(AuthManager.getCredentials(DEFAULT_API_URL)).not.toBeNull();
+  });
+});

--- a/packages/cli/src/auth/auth-manager.ts
+++ b/packages/cli/src/auth/auth-manager.ts
@@ -3,57 +3,196 @@ import * as path from "node:path";
 import * as os from "node:os";
 
 export interface AuthCredentials {
-  sessionToken: string;
-  userId: string;
-  userName: string | null;
-  email: string | null;
-  expiresAt: number;
-  baseUrl: string;
+	sessionToken: string
+	userId: string
+	userName: string | null
+	email: string | null
+	expiresAt: number
+	baseUrl: string
 }
 
-const AUTH_DIR = path.join(os.homedir(), ".nullshot");
-const AUTH_FILE = path.join(AUTH_DIR, "auth.json");
+/** Default API environment when `--api-url` is omitted. */
+export const DEFAULT_API_URL = "https://nullshot.ai"
+
+const AUTH_DIR = path.join(os.homedir(), ".nullshot")
+const AUTH_FILE = path.join(AUTH_DIR, "auth.json")
+
+export interface AuthFileV2 {
+	version: 2
+	credentialsByUrl: Record<string, AuthCredentials>
+}
+
+function authFilePath(): string {
+	return process.env.NULLSHOT_AUTH_FILE ?? AUTH_FILE
+}
+
+/** Normalize API base URL for stable map keys (matches NullshotApiClient trailing-slash behavior). */
+export function normalizeApiUrl(url: string): string {
+	const trimmed = url.trim()
+	if (!trimmed) return DEFAULT_API_URL
+	try {
+		const u = new URL(trimmed)
+		// Rebuild origin + pathname without trailing slash on pathname-only edge cases
+		let out = `${u.protocol}//${u.host}${u.pathname}`
+		out = out.replace(/\/$/, "")
+		return out || DEFAULT_API_URL
+	} catch {
+		return trimmed.replace(/\/$/, "") || DEFAULT_API_URL
+	}
+}
+
+function isExpired(creds: AuthCredentials): boolean {
+	return Boolean(creds.expiresAt && creds.expiresAt < Date.now())
+}
+
+function isLegacyV1Shape(parsed: unknown): parsed is AuthCredentials {
+	if (!parsed || typeof parsed !== "object") return false
+	const o = parsed as Record<string, unknown>
+	return (
+		typeof o.sessionToken === "string" &&
+		(o.version === undefined || o.version !== 2) &&
+		!("credentialsByUrl" in o)
+	)
+}
+
+function isV2Shape(parsed: unknown): parsed is AuthFileV2 {
+	if (!parsed || typeof parsed !== "object") return false
+	const o = parsed as Record<string, unknown>
+	return o.version === 2 && o.credentialsByUrl !== null && typeof o.credentialsByUrl === "object"
+}
+
+function readRawFile(): string | null {
+	const file = authFilePath()
+	try {
+		if (!fs.existsSync(file)) return null
+		return fs.readFileSync(file, "utf-8")
+	} catch {
+		return null
+	}
+}
+
+function parseStoredCredentials(raw: string | null): {
+	credentialsByUrl: Record<string, AuthCredentials>
+} {
+	if (!raw) return { credentialsByUrl: {} }
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(raw) as unknown
+	} catch {
+		return { credentialsByUrl: {} }
+	}
+
+	if (isV2Shape(parsed)) {
+		return { credentialsByUrl: { ...parsed.credentialsByUrl } }
+	}
+
+	if (isLegacyV1Shape(parsed)) {
+		const base = normalizeApiUrl(parsed.baseUrl || DEFAULT_API_URL)
+		const creds: AuthCredentials = {
+			...parsed,
+			baseUrl: base,
+		}
+		if (isExpired(creds)) {
+			return { credentialsByUrl: {} }
+		}
+		return { credentialsByUrl: { [base]: creds } }
+	}
+
+	return { credentialsByUrl: {} }
+}
+
+function dropExpiredEntries(map: Record<string, AuthCredentials>): Record<string, AuthCredentials> {
+	const next: Record<string, AuthCredentials> = {}
+	for (const [key, creds] of Object.entries(map)) {
+		if (!isExpired(creds)) {
+			next[key] = { ...creds, baseUrl: normalizeApiUrl(creds.baseUrl) }
+		}
+	}
+	return next
+}
+
+function writeV2(credentialsByUrl: Record<string, AuthCredentials>): void {
+	const file = authFilePath()
+	const dir = path.dirname(file)
+	if (!fs.existsSync(dir)) {
+		fs.mkdirSync(dir, { recursive: true })
+	}
+	const payload: AuthFileV2 = {
+		version: 2,
+		credentialsByUrl,
+	}
+	fs.writeFileSync(file, JSON.stringify(payload, null, 2), "utf-8")
+	fs.chmodSync(file, 0o600)
+}
 
 export class AuthManager {
-  static getCredentials(): AuthCredentials | null {
-    try {
-      if (!fs.existsSync(AUTH_FILE)) return null;
-      const raw = fs.readFileSync(AUTH_FILE, "utf-8");
-      const creds = JSON.parse(raw) as AuthCredentials;
+	/**
+	 * Credentials for the given API URL, or default production URL when omitted.
+	 */
+	static getCredentials(apiUrl?: string): AuthCredentials | null {
+		const key = normalizeApiUrl(apiUrl ?? DEFAULT_API_URL)
+		const { credentialsByUrl } = parseStoredCredentials(readRawFile())
+		const cleaned = dropExpiredEntries(credentialsByUrl)
+		const creds = cleaned[key]
+		return creds ?? null
+	}
 
-      if (creds.expiresAt && creds.expiresAt < Date.now()) {
-        return null;
-      }
+	/** All non-expired saved sessions, sorted by base URL. */
+	static getAllCredentials(): AuthCredentials[] {
+		const { credentialsByUrl } = parseStoredCredentials(readRawFile())
+		const cleaned = dropExpiredEntries(credentialsByUrl)
+		return Object.values(cleaned).sort((a, b) => a.baseUrl.localeCompare(b.baseUrl))
+	}
 
-      return creds;
-    } catch {
-      return null;
-    }
-  }
+	static saveCredentials(creds: AuthCredentials): void {
+		const key = normalizeApiUrl(creds.baseUrl)
+		const normalized: AuthCredentials = { ...creds, baseUrl: key }
+		const { credentialsByUrl } = parseStoredCredentials(readRawFile())
+		let merged = dropExpiredEntries(credentialsByUrl)
+		merged[key] = normalized
+		writeV2(merged)
+	}
 
-  static saveCredentials(creds: AuthCredentials): void {
-    if (!fs.existsSync(AUTH_DIR)) {
-      fs.mkdirSync(AUTH_DIR, { recursive: true });
-    }
-    fs.writeFileSync(AUTH_FILE, JSON.stringify(creds, null, 2), "utf-8");
-    fs.chmodSync(AUTH_FILE, 0o600);
-  }
+	/**
+	 * Clear stored credentials. No `apiUrl` clears every environment.
+	 */
+	static clearCredentials(apiUrl?: string): void {
+		const file = authFilePath()
+		if (!apiUrl) {
+			try {
+				if (fs.existsSync(file)) {
+					fs.unlinkSync(file)
+				}
+			} catch {
+				// ignore
+			}
+			return
+		}
+		const key = normalizeApiUrl(apiUrl)
+		const { credentialsByUrl } = parseStoredCredentials(readRawFile())
+		let merged = dropExpiredEntries(credentialsByUrl)
+		if (!(key in merged)) {
+			return
+		}
+		delete merged[key]
+		if (Object.keys(merged).length === 0) {
+			try {
+				if (fs.existsSync(file)) {
+					fs.unlinkSync(file)
+				}
+			} catch {
+				// ignore
+			}
+			return
+		}
+		writeV2(merged)
+	}
 
-  static clearCredentials(): void {
-    try {
-      if (fs.existsSync(AUTH_FILE)) {
-        fs.unlinkSync(AUTH_FILE);
-      }
-    } catch {
-      // ignore
-    }
-  }
+	static isAuthenticated(): boolean {
+		return AuthManager.getAllCredentials().length > 0
+	}
 
-  static isAuthenticated(): boolean {
-    return AuthManager.getCredentials() !== null;
-  }
-
-  static getAuthFilePath(): string {
-    return AUTH_FILE;
-  }
+	static getAuthFilePath(): string {
+		return authFilePath()
+	}
 }

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -3,7 +3,7 @@ import { vol } from "memfs";
 import { exec } from "child_process";
 import { TemplateManager } from "./template/template-manager.js";
 import { program } from "./cli.js";
-import { AuthManager } from "./auth/auth-manager.js";
+import { AuthManager, DEFAULT_API_URL } from "./auth/auth-manager.js";
 import { NullshotApiClient } from "./api/nullshot-api-client.js";
 
 vi.mock("fs/promises", () => ({
@@ -103,12 +103,79 @@ describe("CLI Integration", () => {
     expect(program.helpInformation()).toContain("error-check");
   });
 
+  it("exposes logout --api-url in help", () => {
+    const logoutCommand = program.commands.find((command) => command.name() === "logout");
+    expect(logoutCommand?.helpInformation()).toContain("--api-url");
+  });
+
+  it("login --status prints all saved environments", async () => {
+    vi.spyOn(AuthManager, "getAllCredentials").mockReturnValue([
+      {
+        sessionToken: "a",
+        userId: "u1",
+        userName: "Prod",
+        email: "p@x.com",
+        expiresAt: Date.now() + 86400_000,
+        baseUrl: DEFAULT_API_URL,
+      },
+      {
+        sessionToken: "b",
+        userId: "u2",
+        userName: "Dev",
+        email: "d@x.com",
+        expiresAt: Date.now() + 86400_000,
+        baseUrl: "http://localhost:3000",
+      },
+    ]);
+
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.join(" "));
+    });
+
+    await program.parseAsync(["login", "--status"], { from: "user" });
+
+    const output = logs.join("\n");
+    expect(output).toContain("Saved logins");
+    expect(output).toContain("https://nullshot.ai");
+    expect(output).toContain("(default)");
+    expect(output).toContain("http://localhost:3000");
+  });
+
+  it("errors exits when not authenticated for requested --api-url", async () => {
+    vi.spyOn(AuthManager, "getCredentials").mockImplementation((url?: string) => {
+      if (url?.includes("9999")) return null;
+      return {
+        baseUrl: DEFAULT_API_URL,
+        sessionToken: "session-token",
+        email: "user@example.com",
+        userId: "user-1",
+        userName: null,
+        expiresAt: Date.now() + 86400_000,
+      };
+    });
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`EXIT:${code}`);
+    }) as never);
+
+    await expect(
+      program.parseAsync(["errors", "room-1", "--api-url", "http://localhost:9999"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("EXIT:1");
+
+    exitSpy.mockRestore();
+  });
+
   it("formats normalized worker validation output for the errors command", async () => {
     vi.spyOn(AuthManager, "getCredentials").mockReturnValue({
       baseUrl: "http://localhost:3000",
       sessionToken: "session-token",
       email: "user@example.com",
       userId: "user-1",
+      userName: null,
+      expiresAt: Date.now() + 86400_000,
     });
     vi.spyOn(NullshotApiClient.prototype, "getErrors").mockResolvedValue({
       success: false,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -13,7 +13,12 @@ import { CLIError } from "./utils/errors.js";
 import { Logger } from "./utils/logger.js";
 import { TemplateManager } from "./template/template-manager.js";
 import { InputManager } from "./template/input-manager.js";
-import { AuthManager } from "./auth/auth-manager.js";
+import {
+  AuthManager,
+  DEFAULT_API_URL,
+  normalizeApiUrl,
+  type AuthCredentials,
+} from "./auth/auth-manager.js";
 import {
   deriveCodeboxHttpBaseUrl,
   NullshotApiClient,
@@ -30,6 +35,20 @@ import type {
 
 export const program = new Command();
 const logger = new Logger();
+
+function requireCredentialsForApiUrl(apiUrl: string | undefined): AuthCredentials {
+  const target = normalizeApiUrl(apiUrl ?? DEFAULT_API_URL);
+  const creds = AuthManager.getCredentials(target);
+  if (!creds) {
+    const hint =
+      target === normalizeApiUrl(DEFAULT_API_URL)
+        ? "`nullshot login`"
+        : `\`nullshot login --api-url ${target}\``;
+    logger.error(chalk.red(`Not authenticated for ${target}. Run ${hint} first.`));
+    process.exit(1);
+  }
+  return creds;
+}
 
 interface GlobalOptions {
   dryRun?: boolean;
@@ -826,19 +845,28 @@ program
   .option("--api-url <url>", "API base URL override (default: https://nullshot.ai)")
   .action(async (options: { status?: boolean; apiUrl?: string }) => {
     if (options.status) {
-      const creds = AuthManager.getCredentials();
-      if (creds) {
-        logger.info(chalk.green("✅ Authenticated"));
+      const all = AuthManager.getAllCredentials();
+      if (all.length === 0) {
+        logger.info(chalk.yellow("Not authenticated. Run `nullshot login` to authenticate."));
+        return;
+      }
+      logger.info(chalk.green("Saved logins:"));
+      logger.info("");
+      const defaultKey = normalizeApiUrl(DEFAULT_API_URL);
+      for (const creds of all) {
+        const key = normalizeApiUrl(creds.baseUrl);
+        const label =
+          key === defaultKey ? chalk.cyan(`${creds.baseUrl} (default)`) : chalk.cyan(creds.baseUrl);
+        logger.info(label);
         logger.info(`  User: ${creds.userName || creds.userId}`);
         logger.info(`  Email: ${creds.email || "N/A"}`);
         logger.info(`  Expires: ${new Date(creds.expiresAt).toLocaleDateString()}`);
-      } else {
-        logger.info(chalk.yellow("Not authenticated. Run `nullshot login` to authenticate."));
+        logger.info("");
       }
       return;
     }
 
-    const apiBase = options.apiUrl || "https://nullshot.ai";
+    const apiBase = options.apiUrl || DEFAULT_API_URL;
 
     const { createServer } = await import("node:http");
     const { exec } = await import("node:child_process");
@@ -955,7 +983,7 @@ program
       server.on("error", reject);
     });
 
-    const creds = AuthManager.getCredentials();
+    const creds = AuthManager.getCredentials(apiBase);
     spinner.succeed(
       chalk.green(`Authenticated as ${creds?.userName || creds?.email || creds?.userId || "unknown"}`),
     );
@@ -963,10 +991,22 @@ program
 
 program
   .command("logout")
-  .description("Clear stored Nullshot credentials")
-  .action(() => {
+  .description("Clear stored Nullshot credentials (all environments, or one with --api-url)")
+  .option("--api-url <url>", "Only log out this API base URL")
+  .action((options: { apiUrl?: string }) => {
+    if (options.apiUrl) {
+      const key = normalizeApiUrl(options.apiUrl);
+      const before = AuthManager.getCredentials(key);
+      AuthManager.clearCredentials(key);
+      if (!before) {
+        logger.info(chalk.yellow(`No saved login for ${key}.`));
+        return;
+      }
+      logger.info(chalk.green(`Logged out from ${key}.`));
+      return;
+    }
     AuthManager.clearCredentials();
-    logger.info(chalk.green("Logged out successfully."));
+    logger.info(chalk.green("Logged out from all environments."));
   });
 
 // =============================================
@@ -979,14 +1019,10 @@ program
   .argument("[room-id]", "Room ID to sync with directly")
   .option("--api-url <url>", "API base URL override")
   .action(async (roomIdArg?: string, options?: { apiUrl?: string }) => {
-    const creds = AuthManager.getCredentials();
-    if (!creds) {
-      logger.error(chalk.red("Not authenticated. Run `nullshot login` first."));
-      process.exit(1);
-    }
+    const creds = requireCredentialsForApiUrl(options?.apiUrl);
 
     const client = new NullshotApiClient({
-      baseUrl: options?.apiUrl || creds.baseUrl,
+      baseUrl: creds.baseUrl,
       sessionToken: creds.sessionToken,
     });
 
@@ -1223,11 +1259,7 @@ program
   .option("--branch <branch>", "Branch name", "main")
   .option("--api-url <url>", "API base URL override")
   .action(async (roomIdArg?: string, options?: { branch?: string; apiUrl?: string }) => {
-    const creds = AuthManager.getCredentials();
-    if (!creds) {
-      logger.error(chalk.red("Not authenticated. Run `nullshot login` first."));
-      process.exit(1);
-    }
+    const creds = requireCredentialsForApiUrl(options?.apiUrl);
 
     if (!roomIdArg) {
       logger.error(chalk.red("Room ID is required. Usage: nullshot logs <room-id>"));
@@ -1235,7 +1267,7 @@ program
     }
 
     const client = new NullshotApiClient({
-      baseUrl: options?.apiUrl || creds.baseUrl,
+      baseUrl: creds.baseUrl,
       sessionToken: creds.sessionToken,
     });
 
@@ -1295,11 +1327,7 @@ program
   .option("--full", "Show full message content without truncation")
   .option("--api-url <url>", "API base URL override")
   .action(async (roomIdArg?: string, options?: { raw?: boolean; output?: string; full?: boolean; apiUrl?: string }) => {
-    const creds = AuthManager.getCredentials();
-    if (!creds) {
-      logger.error(chalk.red("Not authenticated. Run `nullshot login` first."));
-      process.exit(1);
-    }
+    const creds = requireCredentialsForApiUrl(options?.apiUrl);
 
     if (!roomIdArg) {
       logger.error(chalk.red("Room ID is required. Usage: nullshot messages <room-id>"));
@@ -1307,7 +1335,7 @@ program
     }
 
     const client = new NullshotApiClient({
-      baseUrl: options?.apiUrl || creds.baseUrl,
+      baseUrl: creds.baseUrl,
       sessionToken: creds.sessionToken,
     });
 
@@ -1475,11 +1503,7 @@ program
   .option("--branch <branch>", "Branch name", "main")
   .option("--api-url <url>", "API base URL override")
   .action(async (roomIdArg?: string, options?: { branch?: string; apiUrl?: string }) => {
-    const creds = AuthManager.getCredentials();
-    if (!creds) {
-      logger.error(chalk.red("Not authenticated. Run `nullshot login` first."));
-      process.exit(1);
-    }
+    const creds = requireCredentialsForApiUrl(options?.apiUrl);
 
     if (!roomIdArg) {
       logger.error(chalk.red("Room ID is required. Usage: nullshot errors <room-id>"));
@@ -1487,7 +1511,7 @@ program
     }
 
     const client = new NullshotApiClient({
-      baseUrl: options?.apiUrl || creds.baseUrl,
+      baseUrl: creds.baseUrl,
       sessionToken: creds.sessionToken,
     });
 


### PR DESCRIPTION
## Summary
Stores CLI authentication per API base URL so `--api-url` on `jam`, `logs`, `messages`, and `errors` uses the matching session token. Default environment remains `https://nullshot.ai`.

## Changes
- **auth.json v2**: `credentialsByUrl` keyed by normalized URL; automatic migration from legacy single-object files.
- **`login --status`**: lists all saved environments (marks default production URL).
- **`logout`**: clears all environments; **`logout --api-url <url>`** clears one.
- **Tests**: `auth-manager.test.ts` plus CLI integration coverage.

## How to verify
```bash
pnpm --filter @nullshot/cli run test
```

Made with [Cursor](https://cursor.com)