### PR TITLE
Add CLI resource commands and auth improvements

### DIFF
--- a/packages/cli/src/api/nullshot-api-client.ts
+++ b/packages/cli/src/api/nullshot-api-client.ts
@@ -543,4 +543,335 @@ export class NullshotApiClient {
   getBaseUrl(): string {
     return this.baseUrl;
   }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Generic typed JSON helper for resource endpoints.
+  // ────────────────────────────────────────────────────────────────────────
+  private async request<T>(
+    method: string,
+    path: string,
+    options?: {
+      body?: unknown;
+      query?: Record<string, string | number | undefined>;
+      raw?: boolean;
+    },
+  ): Promise<T> {
+    if (!this.sessionToken) {
+      throw new Error("Not authenticated. Run `nullshot login` first.");
+    }
+
+    let url = `${this.baseUrl}${path}`;
+    if (options?.query) {
+      const qs = new URLSearchParams();
+      for (const [k, v] of Object.entries(options.query)) {
+        if (v === undefined) continue;
+        qs.set(k, String(v));
+      }
+      const s = qs.toString();
+      if (s) url += `?${s}`;
+    }
+
+    const init: RequestInit = {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.sessionToken}`,
+        "Content-Type": "application/json",
+      },
+    };
+    if (options?.body !== undefined) {
+      init.body = JSON.stringify(options.body);
+    }
+
+    const response = await fetch(url, init);
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error("Session expired. Run `nullshot login` to re-authenticate.");
+      }
+      const text = await response.text().catch(() => "");
+      let msg: string | undefined;
+      try {
+        const parsed = JSON.parse(text) as { error?: string; message?: string };
+        msg = parsed.error || parsed.message;
+      } catch {
+        msg = text || undefined;
+      }
+      throw new Error(msg || `${method} ${path} failed (${response.status})`);
+    }
+
+    if (options?.raw) {
+      return response as unknown as T;
+    }
+
+    return (await response.json()) as T;
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Secrets
+  // ────────────────────────────────────────────────────────────────────────
+  async putSecret(roomId: string, key: string, value: string): Promise<{ ok: true }> {
+    return this.request<{ ok: true }>(
+      "PUT",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/secrets/${encodeURIComponent(key)}`,
+      { body: { value } },
+    );
+  }
+
+  async listSecrets(roomId: string): Promise<{ keys: string[] }> {
+    return this.request<{ keys: string[] }>(
+      "GET",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/secrets`,
+    );
+  }
+
+  async deleteSecret(roomId: string, key: string): Promise<{ ok: true }> {
+    return this.request<{ ok: true }>(
+      "DELETE",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/secrets/${encodeURIComponent(key)}`,
+    );
+  }
+
+  async bulkPutSecrets(
+    roomId: string,
+    entries: Array<{ key: string; value: string }>,
+  ): Promise<{ ok: true; count: number }> {
+    return this.request<{ ok: true; count: number }>(
+      "POST",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/secrets/bulk`,
+      { body: { entries } },
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Database
+  // ────────────────────────────────────────────────────────────────────────
+  async createDatabase(
+    roomId: string,
+    binding: string,
+    databaseName: string,
+  ): Promise<{ database_id: string }> {
+    return this.request<{ database_id: string }>(
+      "POST",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/database`,
+      { body: { binding, database_name: databaseName } },
+    );
+  }
+
+  async listDatabases(roomId: string): Promise<{
+    databases: Array<{ binding: string; database_id: string; database_name: string }>;
+  }> {
+    return this.request(
+      "GET",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/database`,
+    );
+  }
+
+  async migrateDatabase(
+    roomId: string,
+    binding: string,
+    migrations: Array<{ name: string; sql: string }>,
+  ): Promise<{ applied: string[]; skipped: string[] }> {
+    return this.request(
+      "POST",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/database/${encodeURIComponent(binding)}/migrate`,
+      { body: { migrations } },
+    );
+  }
+
+  async queryDatabase(
+    roomId: string,
+    binding: string,
+    sql: string,
+    params?: unknown[],
+  ): Promise<{
+    results: unknown[];
+    meta: { rowsRead: number; rowsWritten: number };
+  }> {
+    return this.request(
+      "POST",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/database/${encodeURIComponent(binding)}/query`,
+      { body: params ? { sql, params } : { sql } },
+    );
+  }
+
+  async dumpDatabase(roomId: string, binding: string): Promise<Response> {
+    return this.request<Response>(
+      "GET",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/database/${encodeURIComponent(binding)}/dump`,
+      { raw: true },
+    );
+  }
+
+  async restoreDatabase(
+    roomId: string,
+    binding: string,
+    sql: string,
+  ): Promise<{ ok: true }> {
+    return this.request<{ ok: true }>(
+      "POST",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/database/${encodeURIComponent(binding)}/restore`,
+      { body: { sql } },
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Storage (R2)
+  // ────────────────────────────────────────────────────────────────────────
+  async signStoragePut(
+    roomId: string,
+    binding: string,
+    key: string,
+    contentType: string,
+    contentLength: number,
+  ): Promise<{ url: string; headers?: Record<string, string> }> {
+    return this.request(
+      "POST",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/storage/${encodeURIComponent(binding)}/sign-put`,
+      { body: { key, contentType, contentLength } },
+    );
+  }
+
+  async signStorageGet(
+    roomId: string,
+    binding: string,
+    key: string,
+  ): Promise<{ url: string }> {
+    return this.request(
+      "POST",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/storage/${encodeURIComponent(binding)}/sign-get`,
+      { body: { key } },
+    );
+  }
+
+  async listStorage(
+    roomId: string,
+    binding: string,
+    options?: { prefix?: string; cursor?: string; limit?: number },
+  ): Promise<{
+    objects: Array<{ key: string; size: number; etag: string; uploaded: string }>;
+    cursor?: string;
+  }> {
+    return this.request(
+      "GET",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/storage/${encodeURIComponent(binding)}`,
+      {
+        query: {
+          prefix: options?.prefix,
+          cursor: options?.cursor,
+          limit: options?.limit,
+        },
+      },
+    );
+  }
+
+  async deleteStorage(
+    roomId: string,
+    binding: string,
+    key: string,
+  ): Promise<{ ok: true }> {
+    return this.request<{ ok: true }>(
+      "DELETE",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/storage/${encodeURIComponent(binding)}/${encodeURIComponent(key)}`,
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────────────────
+  // KV
+  // ────────────────────────────────────────────────────────────────────────
+  async listKvKeys(
+    roomId: string,
+    binding: string,
+    options?: { prefix?: string; cursor?: string; limit?: number },
+  ): Promise<{
+    keys: Array<{ name: string; expiration?: number; metadata?: unknown }>;
+    cursor?: string;
+  }> {
+    return this.request(
+      "GET",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/kv/${encodeURIComponent(binding)}`,
+      {
+        query: {
+          prefix: options?.prefix,
+          cursor: options?.cursor,
+          limit: options?.limit,
+        },
+      },
+    );
+  }
+
+  async getKvValue(
+    roomId: string,
+    binding: string,
+    key: string,
+  ): Promise<{ contentType: string; body: string }> {
+    if (!this.sessionToken) {
+      throw new Error("Not authenticated. Run `nullshot login` first.");
+    }
+    const url = `${this.baseUrl}/api/jam/cli/${encodeURIComponent(roomId)}/kv/${encodeURIComponent(binding)}/${encodeURIComponent(key)}`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${this.sessionToken}` },
+    });
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error("Session expired. Run `nullshot login` to re-authenticate.");
+      }
+      const t = await response.text().catch(() => "");
+      throw new Error(t || `Failed to fetch KV key (${response.status})`);
+    }
+    const contentType = response.headers.get("content-type") ?? "text/plain";
+    const body = await response.text();
+    return { contentType, body };
+  }
+
+  async putKvValue(
+    roomId: string,
+    binding: string,
+    key: string,
+    value: string,
+    options?: {
+      expiration?: number;
+      expirationTtl?: number;
+      metadata?: unknown;
+    },
+  ): Promise<{ ok: true }> {
+    const body: Record<string, unknown> = { value };
+    if (options?.expiration !== undefined) body.expiration = options.expiration;
+    if (options?.expirationTtl !== undefined)
+      body.expirationTtl = options.expirationTtl;
+    if (options?.metadata !== undefined) body.metadata = options.metadata;
+
+    return this.request<{ ok: true }>(
+      "PUT",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/kv/${encodeURIComponent(binding)}/${encodeURIComponent(key)}`,
+      { body },
+    );
+  }
+
+  async deleteKvValue(
+    roomId: string,
+    binding: string,
+    key: string,
+  ): Promise<{ ok: true }> {
+    return this.request<{ ok: true }>(
+      "DELETE",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/kv/${encodeURIComponent(binding)}/${encodeURIComponent(key)}`,
+    );
+  }
+
+  async bulkPutKv(
+    roomId: string,
+    binding: string,
+    entries: Array<{
+      key: string;
+      value: string;
+      expirationTtl?: number;
+      metadata?: unknown;
+    }>,
+  ): Promise<{ count: number }> {
+    return this.request<{ count: number }>(
+      "POST",
+      `/api/jam/cli/${encodeURIComponent(roomId)}/kv/${encodeURIComponent(binding)}/bulk`,
+      { body: entries },
+    );
+  }
 }

--- a/packages/cli/src/auth/auth-manager.test.ts
+++ b/packages/cli/src/auth/auth-manager.test.ts
@@ -21,6 +21,11 @@ function sampleCreds(overrides: Partial<AuthCredentials> = {}): AuthCredentials 
   };
 }
 
+function jwtWithExp(exp: number): string {
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
 describe("normalizeApiUrl", () => {
   it("strips trailing slashes and matches DEFAULT", () => {
     expect(normalizeApiUrl("https://nullshot.ai/")).toBe(DEFAULT_API_URL);
@@ -100,6 +105,18 @@ describe("AuthManager", () => {
 
     expect(AuthManager.getCredentials("http://old.local")).toBeNull();
     expect(AuthManager.getCredentials(DEFAULT_API_URL)?.sessionToken).toBe("ok");
+  });
+
+  it("treats an expired JWT session token as expired", () => {
+    AuthManager.saveCredentials(
+      sampleCreds({
+        baseUrl: "https://test.nullshot.ai",
+        sessionToken: jwtWithExp(Math.floor(Date.now() / 1000) - 60),
+        expiresAt: Date.now() + 86400_000,
+      }),
+    );
+
+    expect(AuthManager.getCredentials("https://test.nullshot.ai")).toBeNull();
   });
 
   it("clearCredentials removes entire file when clearing all", () => {

--- a/packages/cli/src/auth/auth-manager.ts
+++ b/packages/cli/src/auth/auth-manager.ts
@@ -41,8 +41,43 @@ export function normalizeApiUrl(url: string): string {
 	}
 }
 
+function decodeJwtExpiresAt(token: string): number | null {
+	const payload = token.split(".")[1]
+	if (!payload) return null
+
+	try {
+		const normalized = payload.replace(/-/g, "+").replace(/_/g, "/")
+		const paddingLength = (4 - (normalized.length % 4)) % 4
+		const padded = normalized.padEnd(normalized.length + paddingLength, "=")
+		const parsed = JSON.parse(Buffer.from(padded, "base64").toString("utf-8")) as unknown
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null
+
+		const exp = (parsed as Record<string, unknown>).exp
+		return typeof exp === "number" && Number.isFinite(exp) ? exp * 1000 : null
+	} catch {
+		return null
+	}
+}
+
+function effectiveExpiresAt(creds: AuthCredentials): number {
+	const jwtExpiresAt = decodeJwtExpiresAt(creds.sessionToken)
+	if (jwtExpiresAt !== null) {
+		return creds.expiresAt ? Math.min(creds.expiresAt, jwtExpiresAt) : jwtExpiresAt
+	}
+	return creds.expiresAt
+}
+
 function isExpired(creds: AuthCredentials): boolean {
-	return Boolean(creds.expiresAt && creds.expiresAt < Date.now())
+	const expiresAt = effectiveExpiresAt(creds)
+	return Boolean(expiresAt && expiresAt < Date.now())
+}
+
+function normalizeCredentials(creds: AuthCredentials): AuthCredentials {
+	return {
+		...creds,
+		baseUrl: normalizeApiUrl(creds.baseUrl),
+		expiresAt: effectiveExpiresAt(creds),
+	}
 }
 
 function isLegacyV1Shape(parsed: unknown): parsed is AuthCredentials {
@@ -105,7 +140,7 @@ function dropExpiredEntries(map: Record<string, AuthCredentials>): Record<string
 	const next: Record<string, AuthCredentials> = {}
 	for (const [key, creds] of Object.entries(map)) {
 		if (!isExpired(creds)) {
-			next[key] = { ...creds, baseUrl: normalizeApiUrl(creds.baseUrl) }
+			next[key] = normalizeCredentials(creds)
 		}
 	}
 	return next
@@ -146,7 +181,7 @@ export class AuthManager {
 
 	static saveCredentials(creds: AuthCredentials): void {
 		const key = normalizeApiUrl(creds.baseUrl)
-		const normalized: AuthCredentials = { ...creds, baseUrl: key }
+		const normalized = normalizeCredentials({ ...creds, baseUrl: key })
 		const { credentialsByUrl } = parseStoredCredentials(readRawFile())
 		let merged = dropExpiredEntries(credentialsByUrl)
 		merged[key] = normalized

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -42,14 +42,18 @@ import type {
 export const program = new Command();
 const logger = new Logger();
 
+function loginCommandForApiUrl(apiUrl: string | undefined): string {
+  const target = normalizeApiUrl(apiUrl ?? DEFAULT_API_URL);
+  return target === normalizeApiUrl(DEFAULT_API_URL)
+    ? "`nullshot login`"
+    : `\`nullshot login --api-url ${target}\``;
+}
+
 function requireCredentialsForApiUrl(apiUrl: string | undefined): AuthCredentials {
   const target = normalizeApiUrl(apiUrl ?? DEFAULT_API_URL);
   const creds = AuthManager.getCredentials(target);
   if (!creds) {
-    const hint =
-      target === normalizeApiUrl(DEFAULT_API_URL)
-        ? "`nullshot login`"
-        : `\`nullshot login --api-url ${target}\``;
+    const hint = loginCommandForApiUrl(target);
     logger.error(chalk.red(`Not authenticated for ${target}. Run ${hint} first.`));
     process.exit(1);
   }
@@ -1046,7 +1050,11 @@ program
       spinner.stop();
 
       if (jams.length === 0) {
-        logger.info(chalk.yellow("No Jams found. Create one at nullshot.ai first."));
+        logger.info(
+          chalk.yellow(
+            `No Jams found for the saved login at ${creds.baseUrl}. If this token expired or no longer has access, run ${loginCommandForApiUrl(creds.baseUrl)} and try again.`,
+          ),
+        );
         return;
       }
 
@@ -1064,7 +1072,11 @@ program
           }
         }
         if (!targetJamName) {
-          logger.error(chalk.red(`Room ${targetRoomId} not found or you don't have access.`));
+          logger.error(
+            chalk.red(
+              `Room ${targetRoomId} not found, or the saved login does not have access. If this token expired or no longer works, run ${loginCommandForApiUrl(creds.baseUrl)} and try again.`,
+            ),
+          );
           process.exit(1);
         }
       } else {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,6 +26,12 @@ import {
 } from "./api/nullshot-api-client.js";
 import { SyncEngine } from "./sync/sync-engine.js";
 import { injectSkills } from "./skills/inject-skills.js";
+import { buildSecretCommand } from "./commands/secret.js";
+import { buildDatabaseCommand } from "./commands/database.js";
+import { buildStorageCommand } from "./commands/storage.js";
+import { buildKvCommand } from "./commands/kv.js";
+import { buildMigrateDataCommand } from "./commands/migrateData.js";
+import { buildDoctorCommand } from "./commands/doctor.js";
 import type {
   MCPConfig,
   InstallOptions,
@@ -1502,7 +1508,17 @@ program
   .argument("[room-id]", "Room ID to fetch errors for")
   .option("--branch <branch>", "Branch name", "main")
   .option("--api-url <url>", "API base URL override")
-  .action(async (roomIdArg?: string, options?: { branch?: string; apiUrl?: string }) => {
+  .option("--diagnose", "Print the full ErrorReport JSON instead of pretty output")
+  .action(async (
+    roomIdArg?: string,
+    options?: { branch?: string; apiUrl?: string; diagnose?: boolean },
+  ) => {
+    const { verbose } = program.opts<GlobalOptions>();
+    if (options?.diagnose && verbose) {
+      logger.error(chalk.red("--diagnose and --verbose are mutually exclusive."));
+      process.exit(1);
+    }
+
     const creds = requireCredentialsForApiUrl(options?.apiUrl);
 
     if (!roomIdArg) {
@@ -1520,7 +1536,11 @@ program
     try {
       const report = await client.getErrors(roomIdArg, options?.branch || "main");
       spinner.stop();
-      printErrorReport(report);
+      if (options?.diagnose) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        printErrorReport(report);
+      }
     } catch (error) {
       spinner.stop();
       if (error instanceof Error) {
@@ -1529,6 +1549,16 @@ program
       process.exit(1);
     }
   });
+
+// =============================================
+// Resource commands (secrets, database, storage, kv, migrate-data, doctor)
+// =============================================
+program.addCommand(buildSecretCommand());
+program.addCommand(buildDatabaseCommand());
+program.addCommand(buildStorageCommand());
+program.addCommand(buildKvCommand());
+program.addCommand(buildMigrateDataCommand());
+program.addCommand(buildDoctorCommand());
 
 process.on("uncaughtException", (error) => {
   logger.error(`${chalk.red("Uncaught exception:")}, ${error}`);

--- a/packages/cli/src/commands/database.ts
+++ b/packages/cli/src/commands/database.ts
@@ -1,0 +1,263 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Command } from "commander";
+import chalk from "chalk";
+import ora from "ora";
+import { resolveResourceContext, reportApiError } from "./shared.js";
+
+interface SharedOpts {
+  roomId?: string;
+  apiUrl?: string;
+}
+
+const DEFAULT_BINDING = "DB";
+const MAX_CHUNK_BYTES = 500 * 1024; // 500 KB
+
+/**
+ * Split a SQL dump on `;\n` into chunks no larger than ~500 KB. Each chunk
+ * still contains complete statements (we never split mid-statement).
+ */
+export function splitSqlChunks(sql: string, maxBytes = MAX_CHUNK_BYTES): string[] {
+  const stmts = sql.split(";\n");
+  const chunks: string[] = [];
+  let current = "";
+  for (const stmt of stmts) {
+    const piece = stmt.endsWith(";") ? stmt : `${stmt};`;
+    if (
+      current &&
+      Buffer.byteLength(current, "utf8") + Buffer.byteLength(piece, "utf8") + 1 >
+        maxBytes
+    ) {
+      chunks.push(current);
+      current = piece;
+    } else {
+      current = current ? `${current}\n${piece}` : piece;
+    }
+  }
+  if (current.trim()) chunks.push(current);
+  return chunks;
+}
+
+function printResultTable(rows: unknown[]): void {
+  if (rows.length === 0) {
+    console.log(chalk.dim("(no rows)"));
+    return;
+  }
+  const objects = rows.map((r) =>
+    r && typeof r === "object" ? (r as Record<string, unknown>) : { value: r },
+  );
+  const columns = Array.from(
+    new Set(objects.flatMap((o) => Object.keys(o))),
+  );
+  const widths: Record<string, number> = {};
+  for (const c of columns) {
+    widths[c] = c.length;
+    for (const o of objects) {
+      const v = o[c];
+      const s = v === null || v === undefined ? "" : String(v);
+      if (s.length > (widths[c] ?? 0)) widths[c] = s.length;
+    }
+    if ((widths[c] ?? 0) > 40) widths[c] = 40;
+  }
+  const header = columns.map((c) => c.padEnd(widths[c] ?? c.length)).join(" │ ");
+  console.log(chalk.bold(header));
+  console.log(chalk.dim("─".repeat(header.length)));
+  for (const o of objects) {
+    const row = columns
+      .map((c) => {
+        const v = o[c];
+        const s = v === null || v === undefined ? "" : String(v);
+        const trimmed =
+          s.length > (widths[c] ?? s.length) ? `${s.slice(0, (widths[c] ?? 1) - 1)}…` : s;
+        return trimmed.padEnd(widths[c] ?? s.length);
+      })
+      .join(" │ ");
+    console.log(row);
+  }
+}
+
+export function buildDatabaseCommand(): Command {
+  const cmd = new Command("database")
+    .alias("db")
+    .description("Manage SQL databases bound to a Jam room");
+
+  cmd
+    .command("list")
+    .description("List configured database bindings")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (opts: SharedOpts) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora("Fetching databases...").start();
+      try {
+        const { databases } = await client.listDatabases(roomId);
+        spinner.stop();
+        if (databases.length === 0) {
+          console.log(chalk.yellow("No databases bound to this room."));
+          return;
+        }
+        for (const db of databases) {
+          console.log(
+            `  ${chalk.cyan(db.binding)}  ${db.database_name}  ${chalk.dim(db.database_id)}`,
+          );
+        }
+      } catch (error) {
+        spinner.stop();
+        reportApiError("List databases", error);
+      }
+    });
+
+  cmd
+    .command("create")
+    .description("Create a new database binding")
+    .requiredOption("--binding <name>", "Binding name")
+    .requiredOption("--name <name>", "Database name")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (opts: SharedOpts & { binding: string; name: string }) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Creating database ${opts.name}...`).start();
+      try {
+        const { database_id } = await client.createDatabase(
+          roomId,
+          opts.binding,
+          opts.name,
+        );
+        spinner.succeed(
+          chalk.green(`Created ${opts.binding} → ${opts.name} (${database_id})`),
+        );
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Create database", error);
+      }
+    });
+
+  cmd
+    .command("migrate")
+    .description("Apply local migrations/*.sql to the remote database")
+    .option("--binding <name>", "Database binding", DEFAULT_BINDING)
+    .option("--dir <path>", "Migrations directory", "migrations")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (opts: SharedOpts & { binding: string; dir: string }) => {
+      const dir = path.resolve(process.cwd(), opts.dir);
+      if (!fs.existsSync(dir)) {
+        console.error(chalk.red(`Migrations directory not found: ${dir}`));
+        process.exit(1);
+      }
+      const files = fs
+        .readdirSync(dir)
+        .filter((f) => f.endsWith(".sql"))
+        .sort();
+      if (files.length === 0) {
+        console.log(chalk.yellow(`No .sql files found in ${dir}`));
+        return;
+      }
+      const migrations = files.map((f) => ({
+        name: f,
+        sql: fs.readFileSync(path.join(dir, f), "utf-8"),
+      }));
+
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(
+        `Applying ${migrations.length} migration(s) to ${opts.binding}...`,
+      ).start();
+      try {
+        const result = await client.migrateDatabase(roomId, opts.binding, migrations);
+        spinner.stop();
+        if (result.applied.length) {
+          console.log(chalk.green(`Applied (${result.applied.length}):`));
+          for (const n of result.applied) console.log(`  + ${n}`);
+        }
+        if (result.skipped.length) {
+          console.log(chalk.dim(`Skipped (${result.skipped.length}):`));
+          for (const n of result.skipped) console.log(chalk.dim(`  · ${n}`));
+        }
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Migrate database", error);
+      }
+    });
+
+  cmd
+    .command("query")
+    .description("Run a SQL query and print results")
+    .argument("<sql>", "SQL statement")
+    .option("--binding <name>", "Database binding", DEFAULT_BINDING)
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (sql: string, opts: SharedOpts & { binding: string }) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora("Running query...").start();
+      try {
+        const { results, meta } = await client.queryDatabase(roomId, opts.binding, sql);
+        spinner.stop();
+        printResultTable(results);
+        console.log(
+          chalk.dim(
+            `\n${results.length} row(s) · read=${meta.rowsRead} written=${meta.rowsWritten}`,
+          ),
+        );
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Query", error);
+      }
+    });
+
+  cmd
+    .command("export")
+    .description("Stream a SQL dump to a local file")
+    .option("--binding <name>", "Database binding", DEFAULT_BINDING)
+    .requiredOption("-o, --output <path>", "Output file path")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (opts: SharedOpts & { binding: string; output: string }) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Dumping ${opts.binding}...`).start();
+      try {
+        const response = await client.dumpDatabase(roomId, opts.binding);
+        const text = await response.text();
+        fs.writeFileSync(opts.output, text, "utf-8");
+        spinner.succeed(
+          chalk.green(`Wrote ${Buffer.byteLength(text, "utf8")} bytes → ${opts.output}`),
+        );
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Export database", error);
+      }
+    });
+
+  cmd
+    .command("import")
+    .description("Restore from a local SQL dump (chunked POSTs)")
+    .option("--binding <name>", "Database binding", DEFAULT_BINDING)
+    .requiredOption("-i, --input <path>", "Input SQL file path")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (opts: SharedOpts & { binding: string; input: string }) => {
+      if (!fs.existsSync(opts.input)) {
+        console.error(chalk.red(`Input file not found: ${opts.input}`));
+        process.exit(1);
+      }
+      const sql = fs.readFileSync(opts.input, "utf-8");
+      const chunks = splitSqlChunks(sql);
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(
+        `Restoring ${chunks.length} chunk(s) to ${opts.binding}...`,
+      ).start();
+      try {
+        for (let i = 0; i < chunks.length; i++) {
+          const chunk = chunks[i];
+          if (chunk === undefined) continue;
+          spinner.text = `Restoring chunk ${i + 1}/${chunks.length}...`;
+          await client.restoreDatabase(roomId, opts.binding, chunk);
+        }
+        spinner.succeed(chalk.green(`Restored ${chunks.length} chunk(s)`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Import database", error);
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,210 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Command } from "commander";
+import chalk from "chalk";
+import { parse as parseJsonc } from "jsonc-parser";
+
+interface Finding {
+  severity: "blocker" | "warn";
+  file: string;
+  line: number;
+  snippet: string;
+  message: string;
+  suggestion: string;
+}
+
+const SCAN_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx"]);
+const IGNORE_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".next",
+  ".open-next",
+  "dist",
+  "build",
+  ".wrangler",
+  ".turbo",
+  ".cache",
+  "out",
+  ".vercel",
+]);
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (IGNORE_DIRS.has(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      out.push(...walk(full));
+    } else if (e.isFile()) {
+      const ext = path.extname(e.name);
+      if (SCAN_EXTENSIONS.has(ext)) out.push(full);
+    }
+  }
+  return out;
+}
+
+function scanFileForCodePatterns(file: string, root: string): Finding[] {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(file, "utf-8");
+  } catch {
+    return [];
+  }
+  const findings: Finding[] = [];
+  const lines = contents.split(/\r?\n/);
+  const rel = path.relative(root, file);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+
+    // Pattern A: `import type { ... } from '@cloudflare/workers-types'`
+    if (/import\s+type\s*\{[^}]*\}\s*from\s*['"]@cloudflare\/workers-types['"]/.test(line)) {
+      findings.push({
+        severity: "warn",
+        file: rel,
+        line: i + 1,
+        snippet: line.trim(),
+        message:
+          "Importing types from @cloudflare/workers-types may not resolve in the playground.",
+        suggestion:
+          "Use a triple-slash directive instead: /// <reference types=\"@cloudflare/workers-types\" />",
+      });
+    }
+
+    // Pattern B: destructuring `ctx` from getCloudflareContext({ async: true })
+    // Match across this line + the next two for multi-line forms.
+    const window = [line, lines[i + 1] ?? "", lines[i + 2] ?? ""].join("\n");
+    if (
+      /\{\s*[^}]*\bctx\b[^}]*\}\s*=\s*await\s+getCloudflareContext\(\s*\{[^}]*\basync\s*:\s*true/.test(
+        window,
+      )
+    ) {
+      findings.push({
+        severity: "blocker",
+        file: rel,
+        line: i + 1,
+        snippet: line.trim(),
+        message:
+          "`ctx` is not available from `getCloudflareContext({ async: true })` in playground.",
+        suggestion:
+          "Drop the `ctx` destructure (only env/cf are available) or guard usage behind a runtime check until the platform polyfill ships.",
+      });
+    }
+  }
+
+  return findings;
+}
+
+function scanWranglerConfig(root: string): Finding[] {
+  const candidates = ["wrangler.jsonc", "wrangler.json", "wrangler.toml"];
+  const findings: Finding[] = [];
+  for (const name of candidates) {
+    const full = path.join(root, name);
+    if (!fs.existsSync(full)) continue;
+    if (!name.endsWith(".jsonc") && !name.endsWith(".json")) continue;
+
+    let raw: string;
+    try {
+      raw = fs.readFileSync(full, "utf-8");
+    } catch {
+      continue;
+    }
+    const config = parseJsonc(raw) as Record<string, unknown> | null;
+    if (!config) continue;
+
+    const previewOnly = ["queues", "workflows", "durable_objects", "vectorize"];
+    for (const key of previewOnly) {
+      if (config[key]) {
+        // Find the line containing this key for nicer reporting.
+        const lineIdx = raw
+          .split(/\r?\n/)
+          .findIndex((l) => l.includes(`"${key}"`));
+        findings.push({
+          severity: "warn",
+          file: name,
+          line: lineIdx >= 0 ? lineIdx + 1 : 1,
+          snippet: `"${key}": …`,
+          message: `Wrangler key "${key}" is not yet fully supported in the playground.`,
+          suggestion: `Note: ${key} works only on real wrangler deploys today; preview is best-effort.`,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+function scanForMissingEnvDts(root: string): Finding[] {
+  const findings: Finding[] = [];
+  const cfDts = path.join(root, "cloudflare-env.d.ts");
+  const wcDts = path.join(root, "worker-configuration.d.ts");
+  if (!fs.existsSync(cfDts) && !fs.existsSync(wcDts)) {
+    findings.push({
+      severity: "warn",
+      file: "(project root)",
+      line: 0,
+      snippet: "",
+      message:
+        "No cloudflare-env.d.ts or worker-configuration.d.ts found at the project root.",
+      suggestion:
+        "Run `wrangler types` (or generate manually) so the playground can typecheck Env bindings.",
+    });
+  }
+  return findings;
+}
+
+export function buildDoctorCommand(): Command {
+  return new Command("doctor")
+    .description("Check the local project for cloud-incompatible patterns")
+    .option("--cwd <path>", "Project root", process.cwd())
+    .action(async (opts: { cwd?: string }) => {
+      const root = path.resolve(opts.cwd ?? process.cwd());
+      const findings: Finding[] = [];
+
+      const sourceFiles = walk(root);
+      for (const file of sourceFiles) {
+        findings.push(...scanFileForCodePatterns(file, root));
+      }
+      findings.push(...scanWranglerConfig(root));
+      findings.push(...scanForMissingEnvDts(root));
+
+      if (findings.length === 0) {
+        console.log(chalk.green("✓ No issues found."));
+        return;
+      }
+
+      const blockers = findings.filter((f) => f.severity === "blocker");
+      const warnings = findings.filter((f) => f.severity === "warn");
+
+      const printGroup = (
+        title: string,
+        list: Finding[],
+        color: (s: string) => string,
+      ): void => {
+        if (list.length === 0) return;
+        console.log(color(`\n${title} (${list.length}):`));
+        for (const f of list) {
+          const loc = f.line > 0 ? `${f.file}:${f.line}` : f.file;
+          console.log(`  ${chalk.dim(loc)}`);
+          console.log(`    ${f.message}`);
+          if (f.snippet) console.log(`    ${chalk.dim(f.snippet)}`);
+          console.log(`    ${chalk.cyan("→")} ${f.suggestion}`);
+        }
+      };
+
+      printGroup("Blockers", blockers, chalk.red.bold);
+      printGroup("Warnings", warnings, chalk.yellow.bold);
+
+      console.log(
+        chalk.dim(
+          `\n${blockers.length} blocker(s), ${warnings.length} warning(s)`,
+        ),
+      );
+      process.exit(blockers.length > 0 ? 1 : 0);
+    });
+}

--- a/packages/cli/src/commands/kv.ts
+++ b/packages/cli/src/commands/kv.ts
@@ -1,0 +1,168 @@
+import * as fs from "node:fs";
+import { Command } from "commander";
+import chalk from "chalk";
+import ora from "ora";
+import { resolveResourceContext, reportApiError } from "./shared.js";
+
+interface SharedOpts {
+  roomId?: string;
+  apiUrl?: string;
+}
+
+const DEFAULT_BINDING = "CACHE";
+
+interface BulkKvEntry {
+  key: string;
+  value: string;
+  expirationTtl?: number;
+  metadata?: unknown;
+}
+
+export function buildKvCommand(): Command {
+  const cmd = new Command("kv").description(
+    "Manage Cloudflare KV namespace for a Jam room",
+  );
+
+  cmd
+    .command("list")
+    .alias("ls")
+    .description("List keys in a KV binding")
+    .option("--binding <name>", "KV binding", DEFAULT_BINDING)
+    .option("--prefix <prefix>", "Key prefix")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (opts: SharedOpts & { binding: string; prefix?: string }) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora("Listing keys...").start();
+      try {
+        let cursor: string | undefined;
+        let total = 0;
+        do {
+          const listOpts: { prefix?: string; cursor?: string } = {};
+          if (opts.prefix !== undefined) listOpts.prefix = opts.prefix;
+          if (cursor !== undefined) listOpts.cursor = cursor;
+          const page = await client.listKvKeys(roomId, opts.binding, listOpts);
+          spinner.stop();
+          for (const k of page.keys) {
+            const exp = k.expiration ? chalk.dim(`(expires ${k.expiration})`) : "";
+            console.log(`  ${k.name} ${exp}`);
+            total++;
+          }
+          cursor = page.cursor;
+          if (cursor) spinner.start("Fetching next page...");
+        } while (cursor);
+        if (total === 0) console.log(chalk.yellow("No keys."));
+        else console.log(chalk.dim(`\n${total} key(s)`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("List KV keys", error);
+      }
+    });
+
+  cmd
+    .command("get")
+    .description("Read a KV value")
+    .argument("<key>", "Key")
+    .option("--binding <name>", "KV binding", DEFAULT_BINDING)
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (key: string, opts: SharedOpts & { binding: string }) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Reading ${key}...`).start();
+      try {
+        const { body } = await client.getKvValue(roomId, opts.binding, key);
+        spinner.stop();
+        console.log(body);
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Get KV", error);
+      }
+    });
+
+  cmd
+    .command("put")
+    .description("Write a KV value")
+    .argument("<key>", "Key")
+    .argument("<value>", "Value")
+    .option("--binding <name>", "KV binding", DEFAULT_BINDING)
+    .option("--ttl <seconds>", "Expiration TTL in seconds", (v) => parseInt(v, 10))
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (
+      key: string,
+      value: string,
+      opts: SharedOpts & { binding: string; ttl?: number },
+    ) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Writing ${key}...`).start();
+      try {
+        const putOpts: { expirationTtl?: number } = {};
+        if (opts.ttl !== undefined) putOpts.expirationTtl = opts.ttl;
+        await client.putKvValue(roomId, opts.binding, key, value, putOpts);
+        spinner.succeed(chalk.green(`Set ${key}`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Put KV", error);
+      }
+    });
+
+  cmd
+    .command("delete")
+    .alias("rm")
+    .description("Delete a KV key")
+    .argument("<key>", "Key")
+    .option("--binding <name>", "KV binding", DEFAULT_BINDING)
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (key: string, opts: SharedOpts & { binding: string }) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Deleting ${key}...`).start();
+      try {
+        await client.deleteKvValue(roomId, opts.binding, key);
+        spinner.succeed(chalk.green(`Deleted ${key}`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Delete KV", error);
+      }
+    });
+
+  cmd
+    .command("bulk")
+    .description("Bulk-write a JSON file of {key,value,...} entries")
+    .argument("<file>", "Path to JSON array file")
+    .option("--binding <name>", "KV binding", DEFAULT_BINDING)
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (file: string, opts: SharedOpts & { binding: string }) => {
+      if (!fs.existsSync(file)) {
+        console.error(chalk.red(`File not found: ${file}`));
+        process.exit(1);
+      }
+      let entries: BulkKvEntry[];
+      try {
+        const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+        if (!Array.isArray(parsed)) {
+          throw new Error("File must contain a JSON array.");
+        }
+        entries = parsed as BulkKvEntry[];
+      } catch (error) {
+        console.error(
+          chalk.red(
+            `Could not parse ${file}: ${error instanceof Error ? error.message : error}`,
+          ),
+        );
+        process.exit(1);
+      }
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Bulk-writing ${entries.length} key(s)...`).start();
+      try {
+        const { count } = await client.bulkPutKv(roomId, opts.binding, entries);
+        spinner.succeed(chalk.green(`Wrote ${count} key(s)`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Bulk KV", error);
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/migrateData.ts
+++ b/packages/cli/src/commands/migrateData.ts
@@ -1,0 +1,206 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Command } from "commander";
+import chalk from "chalk";
+import ora from "ora";
+import { resolveResourceContext } from "./shared.js";
+import { parseDotEnv } from "./secret.js";
+import { splitSqlChunks } from "./database.js";
+import { expandFileGlob } from "./storage.js";
+
+interface MigrateOptions {
+  roomId?: string;
+  apiUrl?: string;
+  secrets?: string;
+  databaseDump?: string;
+  databaseBinding?: string;
+  storageDir?: string;
+  storageBinding?: string;
+  storagePrefix?: string;
+  kvDump?: string;
+  kvBinding?: string;
+  continueOnError?: boolean;
+}
+
+function guessContentType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  const map: Record<string, string> = {
+    ".html": "text/html",
+    ".css": "text/css",
+    ".js": "application/javascript",
+    ".json": "application/json",
+    ".txt": "text/plain",
+    ".md": "text/markdown",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".svg": "image/svg+xml",
+    ".webp": "image/webp",
+    ".pdf": "application/pdf",
+    ".zip": "application/zip",
+  };
+  return map[ext] ?? "application/octet-stream";
+}
+
+export function buildMigrateDataCommand(): Command {
+  return new Command("migrate-data")
+    .description(
+      "Composite import: secrets, database dump, storage dir, and KV dump in one go",
+    )
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .option("--secrets <file>", ".dev.vars-style file to bulk-import")
+    .option("--database-dump <file>", "SQL dump to restore")
+    .option("--database-binding <name>", "Database binding", "DB")
+    .option("--storage-dir <dir>", "Local directory of files to upload")
+    .option("--storage-binding <name>", "Storage binding", "FILE_STORAGE")
+    .option("--storage-prefix <prefix>", "Remote key prefix", "")
+    .option("--kv-dump <file>", "JSON array of {key,value,...} for KV")
+    .option("--kv-binding <name>", "KV binding", "CACHE")
+    .option(
+      "--continue-on-error",
+      "Continue subsequent steps even if one fails",
+      false,
+    )
+    .action(async (opts: MigrateOptions) => {
+      if (
+        !opts.secrets &&
+        !opts.databaseDump &&
+        !opts.storageDir &&
+        !opts.kvDump
+      ) {
+        console.error(
+          chalk.red(
+            "Nothing to do. Pass at least one of --secrets / --database-dump / --storage-dir / --kv-dump.",
+          ),
+        );
+        process.exit(1);
+      }
+
+      const ctxOpts: { apiUrl?: string; roomId?: string } = {};
+      if (opts.apiUrl !== undefined) ctxOpts.apiUrl = opts.apiUrl;
+      if (opts.roomId !== undefined) ctxOpts.roomId = opts.roomId;
+      const { client, roomId } = await resolveResourceContext(ctxOpts);
+      const errors: string[] = [];
+
+      const runStep = async (
+        label: string,
+        fn: () => Promise<void>,
+      ): Promise<void> => {
+        const spinner = ora(label).start();
+        try {
+          await fn();
+          spinner.succeed(chalk.green(label));
+        } catch (error) {
+          spinner.fail(
+            chalk.red(
+              `${label} — ${error instanceof Error ? error.message : String(error)}`,
+            ),
+          );
+          errors.push(label);
+          if (!opts.continueOnError) {
+            console.error(chalk.red("Aborting; pass --continue-on-error to ignore."));
+            process.exit(1);
+          }
+        }
+      };
+
+      // 1) secrets
+      if (opts.secrets) {
+        await runStep(`Importing secrets from ${opts.secrets}`, async () => {
+          if (!fs.existsSync(opts.secrets!)) {
+            throw new Error(`File not found: ${opts.secrets}`);
+          }
+          const entries = parseDotEnv(fs.readFileSync(opts.secrets!, "utf-8"));
+          if (entries.length === 0) return;
+          await client.bulkPutSecrets(roomId, entries);
+        });
+      }
+
+      // 2) database dump
+      if (opts.databaseDump) {
+        await runStep(
+          `Restoring database ${opts.databaseBinding} from ${opts.databaseDump}`,
+          async () => {
+            if (!fs.existsSync(opts.databaseDump!)) {
+              throw new Error(`File not found: ${opts.databaseDump}`);
+            }
+            const sql = fs.readFileSync(opts.databaseDump!, "utf-8");
+            const chunks = splitSqlChunks(sql);
+            for (const c of chunks) {
+              await client.restoreDatabase(roomId, opts.databaseBinding ?? "DB", c);
+            }
+          },
+        );
+      }
+
+      // 3) storage dir
+      if (opts.storageDir) {
+        await runStep(`Uploading ${opts.storageDir} → storage`, async () => {
+          const baseDir = path.isAbsolute(opts.storageDir!)
+            ? opts.storageDir!
+            : path.join(process.cwd(), opts.storageDir!);
+          if (!fs.existsSync(baseDir)) {
+            throw new Error(`Directory not found: ${baseDir}`);
+          }
+          const files = expandFileGlob(opts.storageDir!);
+          for (const file of files) {
+            const rel = path.relative(baseDir, file);
+            const remoteKey = `${(opts.storagePrefix ?? "").replace(/\/$/, "")}/${rel}`
+              .replace(/^\/+/, "")
+              .replace(/\\/g, "/");
+            const stat = fs.statSync(file);
+            const contentType = guessContentType(file);
+            const { url, headers } = await client.signStoragePut(
+              roomId,
+              opts.storageBinding ?? "FILE_STORAGE",
+              remoteKey,
+              contentType,
+              stat.size,
+            );
+            const buf = fs.readFileSync(file);
+            const body = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+            const res = await fetch(url, {
+              method: "PUT",
+              headers: {
+                "Content-Type": contentType,
+                "Content-Length": String(stat.size),
+                ...(headers ?? {}),
+              },
+              body,
+            });
+            if (!res.ok) {
+              const t = await res.text().catch(() => "");
+              throw new Error(`PUT ${remoteKey} failed: ${t || res.status}`);
+            }
+          }
+        });
+      }
+
+      // 4) kv dump
+      if (opts.kvDump) {
+        await runStep(`Importing KV from ${opts.kvDump}`, async () => {
+          if (!fs.existsSync(opts.kvDump!)) {
+            throw new Error(`File not found: ${opts.kvDump}`);
+          }
+          const parsed = JSON.parse(fs.readFileSync(opts.kvDump!, "utf-8"));
+          if (!Array.isArray(parsed)) {
+            throw new Error("KV dump must be a JSON array.");
+          }
+          await client.bulkPutKv(roomId, opts.kvBinding ?? "CACHE", parsed);
+        });
+      }
+
+      if (errors.length > 0) {
+        console.log(
+          chalk.yellow(
+            `\nCompleted with ${errors.length} error(s): ${errors.join(", ")}`,
+          ),
+        );
+        process.exit(1);
+      } else {
+        console.log(chalk.green("\nMigration complete."));
+      }
+    });
+}

--- a/packages/cli/src/commands/secret.ts
+++ b/packages/cli/src/commands/secret.ts
@@ -1,0 +1,175 @@
+import * as fs from "node:fs";
+import { Command } from "commander";
+import chalk from "chalk";
+import ora from "ora";
+import prompts from "prompts";
+import { resolveResourceContext, reportApiError } from "./shared.js";
+
+interface SharedOpts {
+  roomId?: string;
+  apiUrl?: string;
+}
+
+/**
+ * Parses dotenv-style files (`KEY=VALUE` per line). Supports `#` comments and
+ * optional surrounding `'` or `"` quotes.
+ */
+export function parseDotEnv(contents: string): Array<{ key: string; value: string }> {
+  const out: Array<{ key: string; value: string }> = [];
+  const lines = contents.split(/\r?\n/);
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    if (!key) continue;
+    let value = line.slice(eq + 1).trim();
+    // strip surrounding quotes
+    if (
+      (value.startsWith("\"") && value.endsWith("\"")) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out.push({ key, value });
+  }
+  return out;
+}
+
+export function buildSecretCommand(): Command {
+  const cmd = new Command("secret").description(
+    "Manage secrets for a Jam room (Worker bindings)",
+  );
+
+  cmd
+    .command("list")
+    .description("List secret keys (values are never returned)")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (opts: SharedOpts) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora("Fetching secrets...").start();
+      try {
+        const { keys } = await client.listSecrets(roomId);
+        spinner.stop();
+        if (keys.length === 0) {
+          console.log(chalk.yellow("No secrets configured."));
+          return;
+        }
+        for (const k of keys) {
+          console.log(`  ${k}`);
+        }
+      } catch (error) {
+        spinner.stop();
+        reportApiError("List secrets", error);
+      }
+    });
+
+  cmd
+    .command("put")
+    .description("Set a secret value (prompts if --value omitted)")
+    .argument("<key>", "Secret key")
+    .option("--value <value>", "Secret value (otherwise prompted, hidden)")
+    .option("--force", "Overwrite without confirming")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (
+      key: string,
+      opts: SharedOpts & { value?: string; force?: boolean },
+    ) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+
+      if (!opts.force) {
+        try {
+          const { keys } = await client.listSecrets(roomId);
+          if (keys.includes(key)) {
+            const ans = await prompts({
+              type: "confirm",
+              name: "ok",
+              message: `Secret "${key}" already exists — overwrite?`,
+              initial: false,
+            });
+            if (!ans.ok) {
+              console.log(chalk.yellow("Aborted."));
+              return;
+            }
+          }
+        } catch {
+          // best-effort overwrite check; skip if listing fails
+        }
+      }
+
+      let value = opts.value;
+      if (value === undefined) {
+        const ans = await prompts({
+          type: "password",
+          name: "value",
+          message: `Value for ${key}`,
+        });
+        value = typeof ans.value === "string" ? ans.value : undefined;
+        if (value === undefined) {
+          console.log(chalk.yellow("Aborted."));
+          return;
+        }
+      }
+
+      const spinner = ora(`Storing ${key}...`).start();
+      try {
+        await client.putSecret(roomId, key, value);
+        spinner.succeed(chalk.green(`Set ${key}`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Put secret", error);
+      }
+    });
+
+  cmd
+    .command("delete")
+    .alias("rm")
+    .description("Delete a secret")
+    .argument("<key>", "Secret key")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (key: string, opts: SharedOpts) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Deleting ${key}...`).start();
+      try {
+        await client.deleteSecret(roomId, key);
+        spinner.succeed(chalk.green(`Deleted ${key}`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Delete secret", error);
+      }
+    });
+
+  cmd
+    .command("import")
+    .description("Bulk import a .dev.vars-style file (KEY=VALUE per line)")
+    .argument("<file>", "Path to .dev.vars-style file")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (file: string, opts: SharedOpts) => {
+      if (!fs.existsSync(file)) {
+        console.error(chalk.red(`File not found: ${file}`));
+        process.exit(1);
+      }
+      const contents = fs.readFileSync(file, "utf-8");
+      const entries = parseDotEnv(contents);
+      if (entries.length === 0) {
+        console.log(chalk.yellow("No KEY=VALUE pairs found in file."));
+        return;
+      }
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Importing ${entries.length} secret(s)...`).start();
+      try {
+        const result = await client.bulkPutSecrets(roomId, entries);
+        spinner.succeed(chalk.green(`Imported ${result.count} secret(s)`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Import secrets", error);
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/shared.ts
+++ b/packages/cli/src/commands/shared.ts
@@ -1,0 +1,83 @@
+import chalk from "chalk";
+import {
+  AuthManager,
+  DEFAULT_API_URL,
+  normalizeApiUrl,
+  type AuthCredentials,
+} from "../auth/auth-manager.js";
+import { NullshotApiClient } from "../api/nullshot-api-client.js";
+
+export interface ResourceCommandOptions {
+  roomId?: string;
+  apiUrl?: string;
+}
+
+/**
+ * Resolve credentials + room id for any resource command.
+ * Mirrors the existing `requireCredentialsForApiUrl` helper in cli.ts but
+ * additionally resolves a default room id by picking the user's most-recent
+ * jam when --room-id was not supplied.
+ */
+export async function resolveResourceContext(opts: {
+  apiUrl?: string;
+  roomId?: string;
+}): Promise<{
+  client: NullshotApiClient;
+  creds: AuthCredentials;
+  roomId: string;
+}> {
+  const target = normalizeApiUrl(opts.apiUrl ?? DEFAULT_API_URL);
+  const creds = AuthManager.getCredentials(target);
+  if (!creds) {
+    const hint =
+      target === normalizeApiUrl(DEFAULT_API_URL)
+        ? "`nullshot login`"
+        : `\`nullshot login --api-url ${target}\``;
+    console.error(chalk.red(`Not authenticated for ${target}. Run ${hint} first.`));
+    process.exit(1);
+  }
+
+  const client = new NullshotApiClient({
+    baseUrl: creds.baseUrl,
+    sessionToken: creds.sessionToken,
+  });
+
+  let roomId = opts.roomId;
+  if (!roomId) {
+    // Default: first room from the most recent jam.
+    try {
+      const { jams } = await client.listJams();
+      const firstJam = jams[0];
+      const firstRoom = firstJam?.rooms[0];
+      if (!firstRoom) {
+        console.error(
+          chalk.red(
+            "No active jam found. Pass --room-id <id> or run `nullshot jam` first.",
+          ),
+        );
+        process.exit(1);
+      }
+      roomId = firstRoom.id;
+      console.log(
+        chalk.dim(`Using room ${roomId} (${firstJam?.name ?? "unknown jam"})`),
+      );
+    } catch (error) {
+      console.error(
+        chalk.red(
+          error instanceof Error
+            ? `Could not auto-resolve room: ${error.message}`
+            : "Could not auto-resolve room.",
+        ),
+      );
+      process.exit(1);
+    }
+  }
+
+  return { client, creds, roomId };
+}
+
+export function reportApiError(action: string, error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(chalk.red(`${action} failed: ${message}`));
+  process.exit(1);
+}

--- a/packages/cli/src/commands/storage.ts
+++ b/packages/cli/src/commands/storage.ts
@@ -1,0 +1,260 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Command } from "commander";
+import chalk from "chalk";
+import ora from "ora";
+import { resolveResourceContext, reportApiError } from "./shared.js";
+
+interface SharedOpts {
+  roomId?: string;
+  apiUrl?: string;
+}
+
+const DEFAULT_BINDING = "FILE_STORAGE";
+
+/**
+ * Walk a glob pattern relative to cwd. We only support a small useful subset:
+ * - exact paths
+ * - directories (walked recursively)
+ * - patterns of the form `path/**` or `path/**\/*.ext`
+ */
+export function expandFileGlob(pattern: string): string[] {
+  const cwd = process.cwd();
+  const abs = path.isAbsolute(pattern) ? pattern : path.join(cwd, pattern);
+
+  // Strip trailing /** and any wildcard suffix to find a base directory
+  const wildcardIdx = abs.search(/[*?]/);
+  if (wildcardIdx === -1) {
+    if (!fs.existsSync(abs)) return [];
+    const stat = fs.statSync(abs);
+    if (stat.isFile()) return [abs];
+    if (stat.isDirectory()) return walkDir(abs);
+    return [];
+  }
+
+  // Has a wildcard — find the deepest fixed prefix
+  const before = abs.slice(0, wildcardIdx);
+  const baseDir = before.endsWith("/")
+    ? before.slice(0, -1)
+    : path.dirname(before);
+  const tail = abs.slice(baseDir.length + 1);
+
+  if (!fs.existsSync(baseDir)) return [];
+
+  const files = walkDir(baseDir);
+  const regex = globToRegex(tail);
+  return files.filter((f) => regex.test(path.relative(baseDir, f)));
+}
+
+function walkDir(dir: string): string[] {
+  const out: string[] = [];
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    if (e.name === "node_modules" || e.name.startsWith(".")) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      out.push(...walkDir(full));
+    } else if (e.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function globToRegex(glob: string): RegExp {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "§DOUBLESTAR§")
+    .replace(/\*/g, "[^/]*")
+    .replace(/§DOUBLESTAR§/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${escaped}$`);
+}
+
+function guessContentType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  const map: Record<string, string> = {
+    ".html": "text/html",
+    ".css": "text/css",
+    ".js": "application/javascript",
+    ".json": "application/json",
+    ".txt": "text/plain",
+    ".md": "text/markdown",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".svg": "image/svg+xml",
+    ".webp": "image/webp",
+    ".pdf": "application/pdf",
+    ".zip": "application/zip",
+  };
+  return map[ext] ?? "application/octet-stream";
+}
+
+export function buildStorageCommand(): Command {
+  const cmd = new Command("storage").description(
+    "Manage object storage for a Jam room",
+  );
+
+  cmd
+    .command("list")
+    .alias("ls")
+    .description("List objects in a storage binding")
+    .option("--binding <name>", "Storage binding", DEFAULT_BINDING)
+    .option("--prefix <prefix>", "Key prefix")
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (opts: SharedOpts & { binding: string; prefix?: string }) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora("Listing objects...").start();
+      try {
+        let cursor: string | undefined;
+        let total = 0;
+        do {
+          const listOpts: { prefix?: string; cursor?: string } = {};
+          if (opts.prefix !== undefined) listOpts.prefix = opts.prefix;
+          if (cursor !== undefined) listOpts.cursor = cursor;
+          const page = await client.listStorage(roomId, opts.binding, listOpts);
+          spinner.stop();
+          for (const obj of page.objects) {
+            console.log(`  ${obj.key.padEnd(40)} ${obj.size} bytes  ${chalk.dim(obj.uploaded)}`);
+            total++;
+          }
+          cursor = page.cursor;
+          if (cursor) spinner.start("Fetching next page...");
+        } while (cursor);
+        if (total === 0) console.log(chalk.yellow("No objects."));
+        else console.log(chalk.dim(`\n${total} object(s)`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("List storage", error);
+      }
+    });
+
+  cmd
+    .command("upload")
+    .description("Upload local files to storage via signed URL")
+    .argument("<local>", "Local file or glob")
+    .argument("<remote-prefix>", "Remote key prefix")
+    .option("--binding <name>", "Storage binding", DEFAULT_BINDING)
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (
+      local: string,
+      remotePrefix: string,
+      opts: SharedOpts & { binding: string },
+    ) => {
+      const files = expandFileGlob(local);
+      if (files.length === 0) {
+        console.error(chalk.red(`No files matched: ${local}`));
+        process.exit(1);
+      }
+      const { client, roomId } = await resolveResourceContext(opts);
+      const baseDir = path.isAbsolute(local) ? local : path.join(process.cwd(), local);
+      const baseStat = fs.existsSync(baseDir) && fs.statSync(baseDir).isDirectory();
+
+      let succeeded = 0;
+      let failed = 0;
+      for (const file of files) {
+        const rel = baseStat
+          ? path.relative(baseDir, file)
+          : path.basename(file);
+        const remoteKey = `${remotePrefix.replace(/\/$/, "")}/${rel}`.replace(/\\/g, "/");
+        const stat = fs.statSync(file);
+        const contentType = guessContentType(file);
+        const spinner = ora(`Uploading ${rel} → ${remoteKey}...`).start();
+        try {
+          const { url, headers } = await client.signStoragePut(
+            roomId,
+            opts.binding,
+            remoteKey,
+            contentType,
+            stat.size,
+          );
+          const buf = fs.readFileSync(file);
+          // Convert Node Buffer to Uint8Array for fetch BodyInit compatibility.
+          const body = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+          const putRes = await fetch(url, {
+            method: "PUT",
+            headers: {
+              "Content-Type": contentType,
+              "Content-Length": String(stat.size),
+              ...(headers ?? {}),
+            },
+            body,
+          });
+          if (!putRes.ok) {
+            const t = await putRes.text().catch(() => "");
+            throw new Error(t || `PUT failed (${putRes.status})`);
+          }
+          spinner.succeed(chalk.green(`Uploaded ${remoteKey}`));
+          succeeded++;
+        } catch (error) {
+          spinner.fail(
+            chalk.red(
+              `Failed ${rel}: ${error instanceof Error ? error.message : error}`,
+            ),
+          );
+          failed++;
+        }
+      }
+      console.log(
+        chalk.dim(`\n${succeeded} succeeded, ${failed} failed (${files.length} total)`),
+      );
+      if (failed > 0) process.exit(1);
+    });
+
+  cmd
+    .command("download")
+    .description("Download an object via signed URL")
+    .argument("<remote-key>", "Remote key")
+    .argument("[local-path]", "Local path (defaults to basename of key)")
+    .option("--binding <name>", "Storage binding", DEFAULT_BINDING)
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (
+      remoteKey: string,
+      localPath: string | undefined,
+      opts: SharedOpts & { binding: string },
+    ) => {
+      const target = localPath ?? path.basename(remoteKey);
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Fetching ${remoteKey}...`).start();
+      try {
+        const { url } = await client.signStorageGet(roomId, opts.binding, remoteKey);
+        const res = await fetch(url);
+        if (!res.ok) {
+          throw new Error(`Download failed (${res.status})`);
+        }
+        const arr = new Uint8Array(await res.arrayBuffer());
+        fs.writeFileSync(target, arr);
+        spinner.succeed(chalk.green(`Saved ${arr.byteLength} bytes → ${target}`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Download", error);
+      }
+    });
+
+  cmd
+    .command("delete")
+    .alias("rm")
+    .description("Delete an object")
+    .argument("<remote-key>", "Remote key")
+    .option("--binding <name>", "Storage binding", DEFAULT_BINDING)
+    .option("--room-id <id>", "Room ID (defaults to active jam)")
+    .option("--api-url <url>", "API base URL override")
+    .action(async (remoteKey: string, opts: SharedOpts & { binding: string }) => {
+      const { client, roomId } = await resolveResourceContext(opts);
+      const spinner = ora(`Deleting ${remoteKey}...`).start();
+      try {
+        await client.deleteStorage(roomId, opts.binding, remoteKey);
+        spinner.succeed(chalk.green(`Deleted ${remoteKey}`));
+      } catch (error) {
+        spinner.stop();
+        reportApiError("Delete", error);
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/sync/ignore-patterns.test.ts
+++ b/packages/cli/src/sync/ignore-patterns.test.ts
@@ -16,6 +16,17 @@ describe("shouldIgnorePath", () => {
 		expect(shouldIgnorePath("/apps/demo/worker-configuration.d.ts")).toBe(false)
 	})
 
+	it("force-includes generated env type files even when gitignored", () => {
+		// .gitignore commonly excludes these — the CLI must still sync them so
+		// the remote CodeBox has the Env types available for typecheck.
+		expect(
+			shouldIgnorePath("/worker-configuration.d.ts", ["worker-configuration.d.ts"]),
+		).toBe(false)
+		expect(
+			shouldIgnorePath("/cloudflare-env.d.ts", ["cloudflare-env.d.ts", "*.d.ts"]),
+		).toBe(false)
+	})
+
 	it("still respects project-specific ignore patterns", () => {
 		expect(shouldIgnorePath("/internal-docs/spec.md", ["/internal-docs"])).toBe(true)
 		expect(shouldIgnorePath("/src/index.ts", ["/internal-docs"])).toBe(false)

--- a/packages/cli/src/sync/ignore-patterns.ts
+++ b/packages/cli/src/sync/ignore-patterns.ts
@@ -110,6 +110,22 @@ export const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
 ];
 
 /**
+ * Files that MUST be synced even when a project's `.gitignore` (or
+ * `.nullshotignore`) excludes them.
+ *
+ * Cloudflare's generated env type files (`worker-configuration.d.ts` /
+ * `cloudflare-env.d.ts`) are typically gitignored because they're produced
+ * by `wrangler types`. But the remote CodeBox needs them present to typecheck
+ * the user's worker code — without them, every `Env` reference becomes a TS
+ * error and the playground appears broken. We therefore force-include them
+ * regardless of the project's ignore configuration.
+ */
+export const ALWAYS_INCLUDE_PATHS: readonly string[] = [
+  "worker-configuration.d.ts",
+  "cloudflare-env.d.ts",
+];
+
+/**
  * The filename that can be placed in the project root to customise ignore
  * patterns. Follows the same format as .gitignore.
  */
@@ -189,6 +205,17 @@ export function shouldIgnorePath(
   // Normalise: strip leading slash, split into segments
   const normalised = filePath.replace(/^\/+/, "");
   const segments = normalised.split("/");
+
+  // Override: certain generated type files must always be synced even when the
+  // project's .gitignore excludes them — see ALWAYS_INCLUDE_PATHS for the why.
+  for (const forced of ALWAYS_INCLUDE_PATHS) {
+    if (
+      normalised === forced ||
+      segments[segments.length - 1] === forced
+    ) {
+      return false;
+    }
+  }
 
   for (const pattern of allPatterns) {
     // Strip leading slash from pattern (absolute patterns treated as relative)

--- a/packages/cli/src/sync/sync-engine.ts
+++ b/packages/cli/src/sync/sync-engine.ts
@@ -11,6 +11,35 @@ import {
 } from "./ignore-patterns.js";
 import { hashContent, type FileHashMap } from "./content-hash.js";
 
+/**
+ * The codebox stores each synced file as a single SQLite cell in a
+ * Cloudflare Durable Object, which has a hard 1 MiB row size limit
+ * (and a 10 GB total database size limit). Sync attempts that exceed
+ * this raise a SQLITE_TOOBIG error and surface to the user as a blank
+ * preview / handlePreview crash. We refuse oversized files at the CLI
+ * level so the failure happens locally with a clear message instead of
+ * remotely with a stack trace.
+ *
+ * 950 KiB leaves headroom for the JSON envelope the PUT body wraps
+ * around the file content.
+ */
+export const MAX_SYNCED_FILE_BYTES = 950 * 1024;
+
+function isFileTooLarge(absPath: string): { tooBig: boolean; size: number } {
+  try {
+    const { size } = fs.statSync(absPath);
+    return { tooBig: size > MAX_SYNCED_FILE_BYTES, size };
+  } catch {
+    return { tooBig: false, size: 0 };
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
 export interface SyncOptions {
   localDir: string;
   codeboxWsUrl: string;
@@ -250,6 +279,16 @@ export class SyncEngine {
         if (entry.isDirectory()) {
           walk(abs);
         } else if (entry.isFile()) {
+          const { tooBig, size } = isFileTooLarge(abs);
+          if (tooBig) {
+            this.opts.onStatus?.(
+              chalk.yellow(
+                `⚠ skipping ${rel} (${formatBytes(size)} > ${formatBytes(MAX_SYNCED_FILE_BYTES)} cell limit). ` +
+                `Add it to .nullshotignore or split the file.`
+              )
+            );
+            continue;
+          }
           try {
             const content = fs.readFileSync(abs, "utf-8");
             hashes[rel] = hashContent(content);
@@ -346,6 +385,16 @@ export class SyncEngine {
         }
 
         if (change.type === "add" || change.type === "change") {
+          const { tooBig, size } = isFileTooLarge(change.absolutePath);
+          if (tooBig) {
+            this.opts.onStatus?.(
+              chalk.yellow(
+                `⚠ skipping ${change.relativePath} (${formatBytes(size)} > ${formatBytes(MAX_SYNCED_FILE_BYTES)} cell limit). ` +
+                `Add it to .nullshotignore or split the file.`
+              )
+            );
+            return;
+          }
           const content = fs.readFileSync(change.absolutePath, "utf-8");
 
           // If this file was just written from remote and the content hasn't
@@ -561,8 +610,17 @@ export class SyncEngine {
     const response = await fetch(this.codeboxEndpoint(pathname), init);
 
     if (!response.ok) {
-      const text = await response.text().catch(() => "");
-      throw new Error(text || `CodeBox request failed (${response.status})`);
+      const status = response.status;
+      const body = (await response.text().catch(() => "")).trim();
+      const truncated = body.length > 1000 ? `${body.slice(0, 1000)}…` : body;
+      const category =
+        status >= 500
+          ? `Platform error (HTTP ${status}) — retry, and if it persists report it to Nullshot support.`
+          : status >= 400
+            ? `Request rejected (HTTP ${status}) — check your input or auth and try again.`
+            : `CodeBox request failed (HTTP ${status})`;
+      const detail = truncated ? `\nResponse body: ${truncated}` : "";
+      throw new Error(`${method} ${pathname} → ${category}${detail}`);
     }
 
     return response.json() as Promise<T>;
@@ -576,6 +634,14 @@ export class SyncEngine {
   }
 
   private async writeRemoteFile(filePath: string, content: string): Promise<void> {
+    // Last-line defense — defends against any caller that bypassed the
+    // walker / watcher size checks. Mirrors the codebox SQLite cell limit.
+    const byteLength = Buffer.byteLength(content, "utf-8");
+    if (byteLength > MAX_SYNCED_FILE_BYTES) {
+      throw new Error(
+        `Refusing to upload ${filePath}: ${formatBytes(byteLength)} exceeds the ${formatBytes(MAX_SYNCED_FILE_BYTES)} per-file limit (codebox SQLite cell cap is 1 MiB).`
+      );
+    }
     const result = await this.codeboxJsonRequest<{ success: boolean; error?: string }>(
       "PUT",
       `/file?path=${encodeURIComponent(filePath)}`,


### PR DESCRIPTION
## Summary
- Add CLI resource commands for secrets, database, storage, KV, migration, and doctor workflows.
- Store Nullshot CLI auth per API URL and route Jam inspection/sync commands through the matching saved login.
- Detect expired JWT-backed saved sessions and clarify re-login guidance when Jam access looks stale.

## Test plan
- pnpm --filter @nullshot/cli test -- src/auth/auth-manager.test.ts
- pnpm --filter @nullshot/cli test -- src/cli.test.ts
- pnpm --filter @nullshot/cli typecheck


Made with [Cursor](https://cursor.com)